### PR TITLE
Bug caused by version with build number fixed.

### DIFF
--- a/revpi-nodes/libs/socket.js
+++ b/revpi-nodes/libs/socket.js
@@ -225,7 +225,7 @@ module.exports = function (url, config) {
 				if(cb){
 					cb();
 				}
-			}, [pjson.version,options.user,options.password,options.ca]);
+			}, [pjson.version.slice(0, pjson.version.indexOf("-")),options.user,options.password,options.ca]);
 			
         });
 


### PR DESCRIPTION
Only the first part of the version is transmitted from the nodes to the server. So only the part that is in front of the "-" in the version number.